### PR TITLE
removed dashes out of storage account name varible and using rancherE…

### DIFF
--- a/azure-quickstart-templates/rancher-cattle-host-scaling-group-externallbvnet/azuredeploy.json
+++ b/azure-quickstart-templates/rancher-cattle-host-scaling-group-externallbvnet/azuredeploy.json
@@ -32,6 +32,9 @@
     "adminUsername": {
       "type": "string"
     },
+    "rancherEnvironment": {
+      "type": "string"
+    },
     "rancherUrl": {
       "type": "string"
     },
@@ -49,7 +52,7 @@
     "location": "[resourceGroup().location]",
     "rancherEnvVars": "[concat('RANCHER_URL=\"',parameters('rancherUrl'),'\" RANCHER_ACCESS_KEY=\"',parameters('rancherApiAccessKey'),'\" RANCHER_SECRET_KEY=\"',parameters('rancherApiSecretKey'),'\"')]",
     "storageAccountType": "Standard_LRS",
-    "storageAccountName": "[concat(parameters('vmssName'),'-sa-')]",
+    "storageAccountName": "[concat(parameters('rancherEnvironment'),uniquestring(resourceGroup().id),'sa')]",
     "storageAccountid": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
     "nicName": "[concat(parameters('vmssName'), 'nic')]",
     "ipConfigName": "[concat(parameters('vmssName'), 'ipconfig')]",

--- a/azure-quickstart-templates/rancher-cattle-host-scaling-group-externallbvnet/azuredeploy.parameters.json
+++ b/azure-quickstart-templates/rancher-cattle-host-scaling-group-externallbvnet/azuredeploy.parameters.json
@@ -14,7 +14,7 @@
       "metadata": {
         "description": "String used as a base for naming resources (9 characters or less). A hash is prepended to this string for some resources, and resource-specific information is appended."
       },
-      "maxLength": 21
+      "maxLength": 24
     },
     "vNetName": {
       "type": "string",
@@ -158,6 +158,9 @@
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
+          },
+          "rancherEnvironment": {
+            "value": "[parameters('rancherEnvironment')]"
           },
           "rancherUrl": {
             "value": "[parameters('rancherUrl')]"


### PR DESCRIPTION
…nvironment instead of vmssName for variable concat
@ronnytag233 this should keep us under 24 characters and have a unique id plus no dashes in the Storage Account Name...